### PR TITLE
Escape backslash for " content: '\202A' "

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-import-styles",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Injects imported styles (.css or .less) into js",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,11 @@ module.exports = function() {
       ImportDeclaration: {
         exit: cssImport(({ src, css, babelData }) => {
           const { code } = postcss.process(css, src);
+          const escapedCode=code.replace(/\\/g, '\\\\');
           babelData.replaceWith(putStyleIntoHeadAst({
             code: packageName ?
-              `/* ${packageName} */\n${code}` :
-              code
+                `/* ${packageName} */\n${escapedCode}` :
+                escapedCode
           }));
         }),
       },


### PR DESCRIPTION
Without escaping \  , babel can not parse the injected CSS.